### PR TITLE
Fixing proxy configuration section's url in configuration.md

### DIFF
--- a/src/guide/deployment/configuration.md
+++ b/src/guide/deployment/configuration.md
@@ -227,4 +227,4 @@ For reference:
 
 ## Proxy configuration
 
-See [proxy configuration section](/advanced/proxy-headers.md)
+See [proxy configuration section](/guide/advanced/proxy-headers.md)


### PR DESCRIPTION
The **proxy configuration sections's url**  in **configuration.md** is wrong.

I fixed just adding **/guide** to the path.