### PR TITLE
docs(best-practices/blueprints): fix typo

### DIFF
--- a/src/guide/best-practices/blueprints.md
+++ b/src/guide/best-practices/blueprints.md
@@ -257,7 +257,7 @@ The `version` will be prepended to the routes as `/v1` or `/v2`, etc.
 :--:1
 ```python
 auth1 = Blueprint("auth", url_prefix="/auth", version=1)
-auth2 = Blueprint("auth", url_prefix="/auth", verison=2)
+auth2 = Blueprint("auth", url_prefix="/auth", version=2)
 ```
 :---
 


### PR DESCRIPTION
Fixed a simple typo