### PR TITLE
Corrected a minor mistake in the docs

### DIFF
--- a/src/en/guide/advanced/versioning.md
+++ b/src/en/guide/advanced/versioning.md
@@ -38,7 +38,7 @@ def handle_request(request):
 You can also pass a version number to the blueprint, which will apply to all routes in that blueprint.
 :--:1
 ```python
-bp = Blueprint("test", url_prefix="/foo" version=1)
+bp = Blueprint("test", url_prefix="/foo", version=1)
 
 # /v1/foo/text
 @bp.route("/html")


### PR DESCRIPTION

<img width="1011" alt="Screen Shot 2021-05-26 at 12 52 42" src="https://user-images.githubusercontent.com/48620758/119604299-66a1a580-be21-11eb-89a7-78f85bc26836.png">


Found it here: https://sanicframework.org/en/guide/advanced/versioning.html#per-blueprint