### PR TITLE
Rewritten TLS howto

### DIFF
--- a/src/en/guide/how-to/tls.md
+++ b/src/en/guide/how-to/tls.md
@@ -1,75 +1,113 @@
 # TLS/SSL/HTTPS
 
+> Get certificates for your domain names
+
+You can get free certificates from [Let's Encrypt](https://letsencrypt.org/). Install [certbot](https://certbot.eff.org/) via your package manager, and request a certificate:
+
+```sh
+sudo certbot certonly --key-type ecdsa --preferred-chain "ISRG Root X1" -d example.com -d www.example.com
+```
+
+Multiple domain names may be added by further `-d` arguments, all stored into a single certificate which gets saved to `/etc/letsencrypt/live/example.com/` as per **the first domain** that you list here.
+
+The key type and preferred chain options are necessary for getting a minimal size certificate file, essential for making your server run as *fast* as possible. The chain will still contain one RSA certificate until when Let's Encrypt gets their new EC chain trusted in all major browsers, possibly around 2023.
+
 > How do I run Sanic via HTTPS? 
 
 ---:1
-You can use the [`ssl` module](https://docs.python.org/3/library/ssl.html) to create a context and pass it to Sanic
+Let Sanic automatically load your certificate files, which need to be named `fullchain.pem` and `privkey.pem`.
+
+:--:1
+```python
+app.run(
+    host="0.0.0.0", port=443,
+    ssl="/etc/letsencrypt/live/example.com/"
+)
+```
+:---
+
+---:1
+Or, you can pass cert and key filenames separately as a dictionary:
+
+Additionally, `password` may be added if the key is encrypted, all fields except for the password are passed to `request.conn_info.cert`.
+:--:1
+```python
+ssl = {
+    "cert": "/path/to/fullchain.pem",
+    "key": "/path/to/privkey.pem",
+    "password": "for encrypted privkey file",   # Optional
+}
+app.run(host="0.0.0.0", port=8443, ssl=ssl)
+```
+:---
+
+---:1
+Alternatively, [`ssl.SSLContext`](https://docs.python.org/3/library/ssl.html) may be passed, if you need full control over details such as which crypto algorithms are permitted. By default Sanic only permits secure algorithms, which may restrict access from very old devices.
 :--:1
 ```python
 import ssl
 
-context = ssl.create_default_context(
-    purpose=ssl.Purpose.CLIENT_AUTH
-)
-context.load_cert_chain(
-    "/path/to/cert", keyfile="/path/to/keyfile"
-)
+context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+context.load_cert_chain("certs/fullchain.pem", "certs/privkey.pem")
 
 app.run(host="0.0.0.0", port=8443, ssl=context)
 ```
 :---
 
+
+> Multiple domains with separate certificates
+
 ---:1
-Or, you can just pass your key and certificate file paths in a dictionary:
+A list of multiple certificates may be provided, in which case Sanic chooses the one matching the hostname the user is connecting to. This occurs so early in the TLS handshake that Sanic has not sent any packets to the client yet.
+
+If the client sends no SNI (Server Name Indication), the first certificate on the list will be used even though it will likely fail with an SSL error on the client browser. To prevent this fallback and to cause immediate disconnection of clients without a known hostname, add `None` as the first entry on the list.
 :--:1
 ```python
-ssl = {"cert": "/path/to/cert", "key": "/path/to/keyfile"}
+ssl = ["certs/example.com/", "certs/bigcorp.test/"]
+app.run(host="0.0.0.0", port=8443, ssl=ssl)
+```
+:---
+
+---:1
+Dictionaries can be used on the list. This allows also specifying which domains a certificate matches to, although the names present on the certificate itself cannot be controlled from here. If names are not specified, the names from the certificate itself are used.
+
+To only allow connections to the main domain **example.com** and only to subdomains of **bigcorp.test**:
+
+:--:1
+```python
+ssl = [
+    None,  # No fallback if names do not match!
+    {
+        "cert": "certs/example.com/fullchain.pem",
+        "key": "certs/example.com/privkey.pem",
+        "names": ["example.com", "*.bigcorp.test"],
+    }
+]
 app.run(host="0.0.0.0", port=8443, ssl=ssl)
 ```
 :---
 
 > How do I redirect HTTP to HTTPS?
 
+In addition to your normal `app` server running HTTPS, run another server in parallel for redirection:
 ```python
 from sanic import Sanic, response
-
-HTTP_PORT = 80
-HTTPS_PORT = 443
+from multiprocessing import Process
 
 app = Sanic("My App")
-http = Sanic("HTTP Proxy")
 
-app.config.SERVER_NAME = "example.com"
-http.config.SERVER_NAME = "example.com"
+@app.get("/<path:path>")
+def handler(request, path):
+    return response.text(f"Secure connection to {path}")
+
+http = Sanic("HTTP")
 
 @http.get("/<path:path>")
-def proxy(request, path):
-    url = request.app.url_for(
-        "proxy",
-        path=path,
-        _server=https.config.SERVER_NAME,
-        _external=True,
-        _scheme="http",
-    )
-    return response.redirect(url)
+def handler(request, path=""):
+    return response.redirect(f"https://{request.server_name}/{path}")
 
-@app.before_server_start
-async def start(app, _):
-    global http
-    app.http_server = await http.create_server(
-        port=HTTP_PORT, return_asyncio_server=True
-    )
-    app.http_server.after_start()
-
-
-@app.before_server_stop
-async def stop(app, _):
-    app.http_server.before_stop()
-    await app.http_server.close()
-    app.http_server.after_stop()
-
-ssl = {"cert": "/path/to/cert", "key": "/path/to/keyfile"}
-app.run(host="example.com", port=443, ssl=ssl)
+http_server = Process(target=lambda: http.run("0.0.0.0", 80))
+http_server.start()
+app.run("0.0.0.0", 443, ssl="/etc/letsencrypt/live/example.com")
+http_server.join()
 ```
-
-[See forums](https://community.sanicframework.org/t/https-redirection-with-sanic/810) for more complete discussion

--- a/src/en/guide/how-to/tls.md
+++ b/src/en/guide/how-to/tls.md
@@ -42,7 +42,7 @@ app.run(host="0.0.0.0", port=8443, ssl=ssl)
 :---
 
 ---:1
-Alternatively, [`ssl.SSLContext`](https://docs.python.org/3/library/ssl.html) may be passed, if you need full control over details such as which crypto algorithms are permitted. By default Sanic only permits secure algorithms, which may restrict access from very old devices.
+Alternatively, [`ssl.SSLContext`](https://docs.python.org/3/library/ssl.html) may be passed, if you need full control over details such as which crypto algorithms are permitted. By default Sanic only allows secure algorithms, which may restrict access from very old devices.
 :--:1
 ```python
 import ssl
@@ -63,7 +63,7 @@ A list of multiple certificates may be provided, in which case Sanic chooses the
 If the client sends no SNI (Server Name Indication), the first certificate on the list will be used even though on the client browser it will likely fail with a TLS error due to name mismatch. To prevent this fallback and to cause immediate disconnection of clients without a known hostname, add `None` as the first entry on the list.
 
 ::: tip
-You may also use `None` in front of a single certificate if you do not wish to reveal your certificate and true hostname to anyone connecting to the IP address.
+You may also use `None` in front of a single certificate if you do not wish to reveal your certificate, true hostname or site content to anyone connecting to the IP address.
 :::
 
 :--:1
@@ -91,6 +91,14 @@ ssl = [
 app.run(host="0.0.0.0", port=8443, ssl=ssl)
 ```
 :---
+
+> Accessing TLS information in handlers via `request.conn_info` fields
+
+* `.ssl` - is the connection secure (bool)
+* `.cert` - certificate info and dict fields of the currently active cert (dict)
+* `.server_name` - the SNI sent by the client (str, may be empty)
+
+Do note that all `conn_info` fields are per connection, where there may be many requests over time. If a proxy is used in front of your server, these requests on the same pipe may even come from different users.
 
 > How do I redirect HTTP to HTTPS?
 

--- a/src/en/guide/how-to/tls.md
+++ b/src/en/guide/how-to/tls.md
@@ -111,9 +111,9 @@ app.static("/.well-known", "/var/www/.well-known", resource_type="dir")
 @app.exception(exceptions.NotFound, exceptions.MethodNotSupported)
 def redirect_everything_else(request, exception):
     server, path = request.server_name, request.path
-    if not server or not path.startswith('/'):
-        return response.text('Bad Request. Please use HTTPS!', status=400)
-    return response.redirect(f"https://{server}{path}", status=308)
+    if server and path.startswith("/"):
+        return response.redirect(f"https://{server}{path}", status=308)
+    return response.text("Bad Request. Please use HTTPS!", status=400)
 ```
 
 It is best to setup this as a systemd unit separate of your HTTPS servers. You may need to run HTTP while initially requesting your certificates, while you cannot run the HTTPS server yet. Start for IPv4 and IPv6:

--- a/src/en/guide/how-to/tls.md
+++ b/src/en/guide/how-to/tls.md
@@ -60,7 +60,12 @@ app.run(host="0.0.0.0", port=8443, ssl=context)
 ---:1
 A list of multiple certificates may be provided, in which case Sanic chooses the one matching the hostname the user is connecting to. This occurs so early in the TLS handshake that Sanic has not sent any packets to the client yet.
 
-If the client sends no SNI (Server Name Indication), the first certificate on the list will be used even though it will likely fail with an SSL error on the client browser. To prevent this fallback and to cause immediate disconnection of clients without a known hostname, add `None` as the first entry on the list.
+If the client sends no SNI (Server Name Indication), the first certificate on the list will be used even though on the client browser it will likely fail with a TLS error due to name mismatch. To prevent this fallback and to cause immediate disconnection of clients without a known hostname, add `None` as the first entry on the list.
+
+::: tip
+You may also use `None` in front of a single certificate if you do not wish to reveal your certificate and true hostname to anyone connecting to the IP address.
+:::
+
 :--:1
 ```python
 ssl = ["certs/example.com/", "certs/bigcorp.test/"]

--- a/src/en/guide/how-to/tls.md
+++ b/src/en/guide/how-to/tls.md
@@ -103,7 +103,7 @@ def handler(request, path):
 http = Sanic("HTTP")
 
 @http.get("/<path:path>")
-def handler(request, path=""):
+def handler(request, path):
     return response.redirect(f"https://{request.server_name}/{path}")
 
 http_server = Process(target=lambda: http.run("0.0.0.0", 80))

--- a/src/en/guide/how-to/tls.md
+++ b/src/en/guide/how-to/tls.md
@@ -63,7 +63,7 @@ A list of multiple certificates may be provided, in which case Sanic chooses the
 If the client sends no SNI (Server Name Indication), the first certificate on the list will be used even though on the client browser it will likely fail with a TLS error due to name mismatch. To prevent this fallback and to cause immediate disconnection of clients without a known hostname, add `None` as the first entry on the list.
 
 ::: tip
-You may also use `None` in front of a single certificate if you do not wish to reveal your certificate, true hostname or site content to anyone connecting to the IP address.
+You may also use `None` in front of a single certificate if you do not wish to reveal your certificate, true hostname or site content to anyone connecting to the IP address instead of the proper DNS name.
 :::
 
 :--:1


### PR DESCRIPTION
Expanded and clarified existing text, added the new features implemented in https://github.com/sanic-org/sanic/pull/2270

The HTTP to HTTPS example was broken. <strike>Patched by using multiprocessing, but might need an update once that can be done without spawning extra processes.</strike> Also, neither `app.url_for` nor `request.url_for` is really suited for this, while a simple format string gets the job done nicely.