### PR TITLE
Manually set app is_started flag in example code

### DIFF
--- a/src/en/guide/how-to/tls.md
+++ b/src/en/guide/how-to/tls.md
@@ -148,6 +148,7 @@ async def runner(app, app_server):
     try:
         app.signalize()
         app.finalize()
+        app.state.is_started = True
         await app_server.serve_forever()
     finally:
         app.is_running = False


### PR DESCRIPTION
When the startup is done manually, the app is_started flag need to be set manually.

Fixes sanic-org/sanic#2374