### PR TITLE
Fix Sanic app name

### DIFF
--- a/src/en/guide/basics/app.md
+++ b/src/en/guide/basics/app.md
@@ -10,7 +10,7 @@ The most basic building block is the `Sanic()` instance. It is not required, but
 
 from sanic import Sanic
 
-app = Sanic("My Hello, world app")
+app = Sanic("MyHelloWorldApp")
 ```
 :---
 


### PR DESCRIPTION
Names must begin with a character and may only contain alphanumeric characters, _, or -.