### PR TITLE
Fix Blueprints versioning example

### DIFF
--- a/src/en/guide/best-practices/blueprints.md
+++ b/src/en/guide/best-practices/blueprints.md
@@ -326,7 +326,7 @@ same time.
 auth = Blueprint("auth", url_prefix="/auth")
 metrics = Blueprint("metrics", url_prefix="/metrics")
 
-group = Blueprint.group([auth, metrics], version="v1")
+group = Blueprint.group(auth, metrics, version="v1")
 
 # This will provide APIs prefixed with the following URL path
 # /v1/auth/ and /v1/metrics

--- a/src/zh/guide/best-practices/blueprints.md
+++ b/src/zh/guide/best-practices/blueprints.md
@@ -335,7 +335,7 @@ app.blueprint(auth2)
 auth = Blueprint("auth", url_prefix="/auth")
 metrics = Blueprint("metrics", url_prefix="/metrics")
 
-group = Blueprint.group([auth, metrics], version="v1")
+group = Blueprint.group(auth, metrics, version="v1")
 
 # This will provide APIS prefixed with the following URL path
 # /v1/auth/ and /v1/metrics


### PR DESCRIPTION
There is a mistake in the Blueprint best practice documentation page. 

Fix in `en` and `zh`. No documentation found in `ko`