### PR TITLE
Fix broken syntax

### DIFF
--- a/src/en/guide/how-to/orm.md
+++ b/src/en/guide/how-to/orm.md
@@ -21,7 +21,7 @@ Because [SQLAlchemy 1.4](https://docs.sqlalchemy.org/en/14/changelog/changelog_1
 
 ### Dependencies
 
-First, we need to install the required dependencies. In the past, the dependencies installed were `sqlalchemy` and `pymysql`, but now`sqlalchemy' and `aiomysql` are needed.
+First, we need to install the required dependencies. In the past, the dependencies installed were `sqlalchemy` and `pymysql`, but now `sqlalchemy` and `aiomysql` are needed.
 
 :--:1
 


### PR DESCRIPTION
There is a minor issue with the inline code blocks in `en/guide/how-to/orm.md` resulting in [broken formatting](https://sanic.dev/en/guide/how-to/orm.html#sqlalchemy):

![grafik](https://user-images.githubusercontent.com/26834699/162489365-e29d3e7f-6e76-41e7-9320-fe6aff9043f4.png)
