### PR TITLE
modify the lowest version of python

### DIFF
--- a/src/zh/plugins/sanic-ext/getting-started.md
+++ b/src/zh/plugins/sanic-ext/getting-started.md
@@ -13,7 +13,7 @@ Sanic Extensions 是一个由 SCO *官方开发和维护的* 插件。这个项�
 
 ## 最低要求（Minimum requirements）
 
-- **Python**: 3.7+
+- **Python**: 3.8+
 - **Sanic**: 21.9+
 
 ## 安装（Install）


### PR DESCRIPTION
### python 3.7.* is not adapted
  *  assignment expresions is not supported 
  *  importlib don't have metadata module, maybe you need importlib_metadata
  *  stdlib has an older version of typing.py and won't be updated  e.g: typing. Literal
  * ...

### so you need python3.8+