### PR TITLE
Fix broken internal links

### DIFF
--- a/src/en/guide/deployment/running.md
+++ b/src/en/guide/deployment/running.md
@@ -248,7 +248,7 @@ app.run(version=3)
 ```
 :---
 
-To run both an HTTP/3 and HTTP/1.1 server simultaneously, you can use [application multi-serve](http://localhost:8080/en/guide/release-notes/v22.3.html#application-multi-serve) introduced in v22.3. This will automatically add an [Alt-Svc](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Alt-Svc) header to your HTTP/1.1 requests to let the client know that it is also available as HTTP/3.
+To run both an HTTP/3 and HTTP/1.1 server simultaneously, you can use [application multi-serve](../release-notes/v22.3.html#application-multi-serve) introduced in v22.3. This will automatically add an [Alt-Svc](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Alt-Svc) header to your HTTP/1.1 requests to let the client know that it is also available as HTTP/3.
 
 
 ---:1
@@ -268,7 +268,7 @@ Sanic.serve()
 ```
 :---
 
-Because HTTP/3 requires TLS, you cannot start a HTTP/3 server without a TLS certificate. You should [set it up yourself](http://localhost:8080/en/guide/how-to/tls.html) or use `mkcert` if in `DEBUG` mode. Currently, automatic TLS setup for HTTP/3 is not compatible with `trustme`. See [development](./development.md) for more details.
+Because HTTP/3 requires TLS, you cannot start a HTTP/3 server without a TLS certificate. You should [set it up yourself](../how-to/tls.html) or use `mkcert` if in `DEBUG` mode. Currently, automatic TLS setup for HTTP/3 is not compatible with `trustme`. See [development](./development.md) for more details.
 
 :::
 

--- a/src/en/guide/release-notes/v22.6.md
+++ b/src/en/guide/release-notes/v22.6.md
@@ -60,7 +60,7 @@ app.run(version=3)
 ```
 :---
 
-To run both an HTTP/3 and HTTP/1.1 server simultaneously, you can use [application multi-serve](http://localhost:8080/en/guide/release-notes/v22.3.html#application-multi-serve) introduced in v22.3.
+To run both an HTTP/3 and HTTP/1.1 server simultaneously, you can use [application multi-serve](./v22.3.html#application-multi-serve) introduced in v22.3.
 
 
 ---:1
@@ -80,7 +80,7 @@ Sanic.serve()
 ```
 :---
 
-Because HTTP/3 requires TLS, you cannot start a HTTP/3 server without a TLS certificate. You should [set it up yourself](http://localhost:8080/en/guide/how-to/tls.html) or use `mkcert` if in `DEBUG` mode. Currently, automatic TLS setup for HTTP/3 is not compatible with `trustme`.
+Because HTTP/3 requires TLS, you cannot start a HTTP/3 server without a TLS certificate. You should [set it up yourself](../how-to/tls.html) or use `mkcert` if in `DEBUG` mode. Currently, automatic TLS setup for HTTP/3 is not compatible with `trustme`.
 
 **:baby: This feature is being released as an *EARLY RELEASE FEATURE*.** It is **not** yet fully compliant with the HTTP/3 specification, lacking some features like [websockets](https://websockets.spec.whatwg.org/), [webtransport](https://w3c.github.io/webtransport/), and [push responses](https://http3-explained.haxx.se/en/h3/h3-push). Instead the intent of this release is to bring the existing HTTP request/response cycle towards feature parity with HTTP/3. Over the next several releases, more HTTP/3 features will be added and the API for it finalized.
 


### PR DESCRIPTION
While surfing through documentation I found out some broken links that lead to development server absolute paths