### PR TITLE
class-based-views fix syntax highlighting

### DIFF
--- a/src/en/guide/advanced/class-based-views.md
+++ b/src/en/guide/advanced/class-based-views.md
@@ -161,7 +161,7 @@ class ViewWithSomeDecorator(HTTPMethodView):
         return text("Hello I have a decorator")
 
     def post(self, request, name):
-        return text("Hello I don"t have any decorators")
+        return text("Hello I do not have any decorators")
 
     @some_decorator_here
     def patch(self, request, name):


### PR DESCRIPTION
Fix syntax highlighting, removed quote entirely becausei noticed almost all places in which there could be a contraction they are just separated into whole words.