### PR TITLE
Removing 3 unnecessary ticks

### DIFF
--- a/src/en/guide/basics/routing.md
+++ b/src/en/guide/basics/routing.md
@@ -627,7 +627,6 @@ Retrieving the URLs works similar to handlers. But, we can also add the `filenam
 )
 '/static/file.txt'
 
-```python
 >>> app.url_for(
     "static",
     name="uploads",


### PR DESCRIPTION
Removing 3 unnecessary back ticks for 4th python code block.

https://sanic.dev/en/guide/basics/routing.html#static-files