### PR TITLE
Apply removal of some websocket config in 21.9

### DIFF
--- a/src/en/guide/advanced/websockets.md
+++ b/src/en/guide/advanced/websockets.md
@@ -71,9 +71,6 @@ See [configuration section](/guide/deployment/configuration.md) for more details
 
 ```python
 app.config.WEBSOCKET_MAX_SIZE = 2 ** 20
-app.config.WEBSOCKET_MAX_QUEUE = 32
-app.config.WEBSOCKET_READ_LIMIT = 2 ** 16
-app.config.WEBSOCKET_WRITE_LIMIT = 2 ** 16
 app.config.WEBSOCKET_PING_INTERVAL = 20
 app.config.WEBSOCKET_PING_TIMEOUT = 20
 ```


### PR DESCRIPTION
https://sanic.dev/en/guide/release-notes/v21.9.html#removal-of-config-values-websocket-read-limit-websocket-write-limit-and-websocket-max-queue