### PR TITLE
prepare method spell mistake

### DIFF
--- a/src/en/guide/deployment/running.md
+++ b/src/en/guide/deployment/running.md
@@ -339,8 +339,8 @@ $ sanic path.to.server:app -3 -1
 :--:1
 
 ```python
-app.prepre(version=3)
-app.prepre(version=1)
+app.prepare(version=3)
+app.prepare(version=1)
 Sanic.serve()
 ```
 :---


### PR DESCRIPTION
app.prepare() is written as app.prepre()


https://sanic.dev/en/guide/deployment/running.html#http-3