### PR TITLE
Remove ^-operator

### DIFF
--- a/src/en/guide/basics/routing.md
+++ b/src/en/guide/basics/routing.md
@@ -349,7 +349,7 @@ It does *not* support the `path` parameter type.
 ::: tab regex
 
 ```python
-@app.route(r"/path/to/<foo:^([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))>")
+@app.route(r"/path/to/<foo:([12]\d{3}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))>")
 async def handler(request, foo: str):
     ...
 ```


### PR DESCRIPTION
The regex ^-operator matches the beginning of a string.