### PR TITLE
Fix for disabling the loading of environment variabes

### DIFF
--- a/src/en/guide/deployment/configuration.md
+++ b/src/en/guide/deployment/configuration.md
@@ -68,7 +68,7 @@ $ export MYAPP_REQUEST_TIMEOUT=10
 You can also disable environment variable loading completely.
 :--:1
 ```python
-app = Sanic(__name__, load_env=False)
+app = Sanic(__name__, env_prefix=None)
 ```
 :---
 

--- a/src/ja/guide/deployment/configuration.md
+++ b/src/ja/guide/deployment/configuration.md
@@ -57,7 +57,7 @@ $ export SANIC_REQUEST_TIMEOUT=10
 $ export MYAPP_REQUEST_TIMEOUT=10
 ```
 ```python
->>> app = Sanic(__name__, load_env='MYAPP_')
+>>> app = Sanic(__name__, env_prefix='MYAPP_')
 >>> print(app.config.REQUEST_TIMEOUT)
 10
 ```

--- a/src/ja/guide/deployment/configuration.md
+++ b/src/ja/guide/deployment/configuration.md
@@ -68,7 +68,7 @@ $ export MYAPP_REQUEST_TIMEOUT=10
 環境変数のロードを完全に無効にすることもできます。
 :--:1
 ```python
-app = Sanic(__name__, load_env=False)
+app = Sanic(__name__, env_prefix=None)
 ```
 :---
 

--- a/src/zh/guide/deployment/configuration.md
+++ b/src/zh/guide/deployment/configuration.md
@@ -71,7 +71,7 @@ $ export MYAPP_REQUEST_TIMEOUT=10
 ```
 
 ```python
->>> app = Sanic(__name__, load_env='MYAPP_')
+>>> app = Sanic(__name__, env_prefix='MYAPP_')
 >>> print(app.config.REQUEST_TIMEOUT)
 10
 ```

--- a/src/zh/guide/deployment/configuration.md
+++ b/src/zh/guide/deployment/configuration.md
@@ -85,7 +85,7 @@ $ export MYAPP_REQUEST_TIMEOUT=10
 :--:1
 
 ```python
-app = Sanic(__name__, load_env=False)
+app = Sanic(__name__, env_prefix=None)
 ```
 
 :---


### PR DESCRIPTION
Also corrected a few places in translated pages where `load_env` was used where `env_prefix` should have been.