### PR TITLE
fix sanic-ext EN configuration typo

### DIFF
--- a/src/en/plugins/sanic-ext/configuration.md
+++ b/src/en/plugins/sanic-ext/configuration.md
@@ -200,7 +200,7 @@ Be very careful if you place `*` here. Do not do this unless you know what you a
 
 - **Type**: `str`
 - **Default**: `"/swagger-config"`
-- **Description**: Path to serve the Swagger configurtaion
+- **Description**: Path to serve the Swagger configuration
 
 ### `oas_uri_to_json`
 


### PR DESCRIPTION
Fixing simple typo found in the sanic-ext configuration docs.
configurtaion -> configuration